### PR TITLE
Add Content Directory feature (File > Add Content Directory, Ctrl+O)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -779,3 +779,39 @@ When all `content_roots` in `~/.swiftrc` pointed to inaccessible filesystems (e.
 ### Rule
 
 **Never let filesystem I/O prevent runtime keys from being set.** Wrap `os.makedirs()` for user-configured paths in try/except and always set the runtime-derived keys, even if the directories don't exist on disk. The app should start and let the user navigate to an accessible location.
+
+## Add Content Directory Feature (2026-03-30)
+
+Added **File > Add Content Directory... (Ctrl+O)** to let users browse to an existing `alignem_data` directory and register it as a content root. Its emstacks and alignments then appear in the Alignment Manager's combo dropdowns.
+
+### Design Decision
+
+The feature adds a content root (directory), not opening a specific `.align` file, because:
+- An `alignem_data` directory can contain multiple emstacks and alignments
+- The existing workflow (select emstack from combo → select alignment from combo) is preserved
+- The DirectoryWatcher mechanism already handles discovery and combo population
+
+### Files Changed
+
+| File | Changes |
+|---|---|
+| `src/ui/main_window.py` | New `addContentDirAction` menu action (Ctrl+O) → `open_project_file()` method; uses `QFileDialog` with custom "Add" button label and directory-only mode |
+| `src/ui/tabs/manager.py` | `_addContentRoot()` now calls `updateCombos()` after adding a root — `QFileSystemWatcher` only emits on changes after watching starts, not for existing contents |
+
+### How It Works
+
+1. **File > Add Content Directory...** opens a directory browser (dialog title: "Add Content Directory", accept button: "Add")
+2. Dialog starts at the parent of the first known content root
+3. If the user selects a directory containing an `alignem_data` subdirectory, auto-resolves into it
+4. Validates the directory has `images/` or `alignments/` subdirs — shows a warning if not
+5. Calls `_addContentRoot()` which adds to `content_roots`, creates subdirs if needed, updates DirectoryWatchers, and saves `.swiftrc`
+6. Calls `updateCombos()` to immediately populate the emstack/alignment combos with discovered items
+7. Switches to the Alignment Manager tab
+
+### Bug Fix: Combos Not Populated After Adding Content Root
+
+`_addContentRoot()` called `_syncContentRoots()` → `_updateWatchPaths()` which registered new directories with `QFileSystemWatcher`. However, `QFileSystemWatcher.directoryChanged` only fires when directory contents change *after* watching starts — it does not emit for existing contents. Added explicit `updateCombos()` call at the end of `_addContentRoot()` to force an immediate scan.
+
+### Rule
+
+**Always call `updateCombos()` after programmatically adding watch paths.** `QFileSystemWatcher` does not emit signals for pre-existing directory contents — only for changes that occur after the watch is established.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1756,6 +1756,46 @@ class MainWindow(QMainWindow):
                 return
         self.globTabs.addTab(self.pm, 'Alignment Manager')
 
+    def open_project_file(self):
+        '''Browse to an alignem_data directory and add it as a content root.
+        Its emstacks and alignments become available in the Alignment Manager combos.'''
+        logger.info('')
+        start_dir = cfg.preferences.get('content_roots', [os.path.expanduser('~')])[0]
+        start_dir = os.path.dirname(start_dir) if os.path.isdir(start_dir) else os.path.expanduser('~')
+        dlg = QFileDialog(self, "Add Content Directory", start_dir)
+        dlg.setFileMode(QFileDialog.Directory)
+        dlg.setOption(QFileDialog.ShowDirsOnly, True)
+        dlg.setLabelText(QFileDialog.Accept, "Add")
+        if not dlg.exec():
+            return
+        chosen = dlg.selectedFiles()[0]
+        if not chosen:
+            return
+
+        # Auto-append alignem_data if the user selected a parent directory
+        if not os.path.basename(chosen) == 'alignem_data':
+            candidate = os.path.join(chosen, 'alignem_data')
+            if os.path.isdir(candidate):
+                chosen = candidate
+
+        # Verify it looks like a valid content root (has images/ or alignments/ subdirs)
+        has_images = os.path.isdir(os.path.join(chosen, 'images'))
+        has_alignments = os.path.isdir(os.path.join(chosen, 'alignments'))
+        if not has_images and not has_alignments:
+            QMessageBox.warning(self, "Invalid Directory",
+                f"The selected directory does not contain 'images' or 'alignments' subdirectories:\n\n{chosen}\n\n"
+                "Please select an alignem_data directory.")
+            return
+
+        # Ensure the ManagerTab exists, add the content root, and switch to it
+        self.open_project_new()
+        for i in range(self.globTabs.count()):
+            widget = self.globTabs.widget(i)
+            if widget.__class__.__name__ == 'ManagerTab':
+                widget._addContentRoot(chosen)
+                self.tell(f"Added content root: {chosen}")
+                return
+
     def detachNeuroglancer(self):
         logger.info('')
         if self._isProjectTab() or self._isZarrTab():
@@ -3174,17 +3214,16 @@ class MainWindow(QMainWindow):
         # self.addAction(self.refreshAction)
         fileMenu.addAction(self.refreshAction)
 
-        self.openAction = QAction('&Open Alignment Manager...', self)
-        # self.openAction.triggered.connect(self.open_project)
+        self.addContentDirAction = QAction('&Add Content Directory...', self)
+        self.addContentDirAction.triggered.connect(self.open_project_file)
+        self.addContentDirAction.setShortcut('Ctrl+O')
+        self.addAction(self.addContentDirAction)
+        fileMenu.addAction(self.addContentDirAction)
+
+        self.openAction = QAction('Open Alignment &Manager...', self)
         self.openAction.triggered.connect(self.open_project_new)
-        # self.openAction.setShortcut('Ctrl+O')
         self.addAction(self.openAction)
         fileMenu.addAction(self.openAction)
-
-        # self.openArbitraryZarrAction = QAction('Open &Zarr...', self)
-        # self.openArbitraryZarrAction.triggered.connect(self.open_zarr_selected)
-        # self.openArbitraryZarrAction.setShortcut('Ctrl+Z')
-        # fileMenu.addAction(self.openArbitraryZarrAction)
 
         exportMenu = fileMenu.addMenu('Export')
 

--- a/src/ui/tabs/manager.py
+++ b/src/ui/tabs/manager.py
@@ -895,6 +895,8 @@ class ManagerTab(QWidget):
             os.makedirs(os.path.join(root, 'alignments'), exist_ok=True)
             self._syncContentRoots()
             self._populateContentRootCombo()
+        # Always refresh combos — QFileSystemWatcher doesn't emit for existing contents
+        self.updateCombos()
 
     def _syncContentRoots(self):
         '''Derive search paths from content_roots, update watchers.'''


### PR DESCRIPTION
Allow users to browse to an existing alignem_data directory and register it as a content root. Emstacks and alignments are immediately discovered and populated in the Alignment Manager combos. Also fixes combo population after adding a root — QFileSystemWatcher doesn't emit for pre-existing directory contents, so an explicit updateCombos() call is now made.